### PR TITLE
Buxfix - crased on delete last symbol in Filename format

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -63,15 +63,17 @@ after_build:
   - if "%PLATFORM%" EQU "X64" (xcopy "openssl-utils.git\win64\*.dll" "distrib\flameshot")
   - if "%PLATFORM%" EQU "x86" (xcopy "openssl-utils.git\win32\*.dll" "distrib\flameshot")
   - cd distrib
+  - if "%PLATFORM%" EQU "X64" (mv flameshot\vcredist_x64.exe flameshot\vcredist.exe)
+  - if "%PLATFORM%" EQU "x86" (mv flameshot\vcredist_x86.exe flameshot\vcredist.exe)
   - 7z a flameshot_%flameshot_version%_win_%PLATFORM%.zip flameshot
   # Build installation
   - cp ..\..\win_setup\flameshot.iss flameshot.iss
   - C:\InnoSetup\Compil32.exe /cc flameshot.iss
-  - mv Output\Flameshot-Setup.exe Output\Flameshot-Setup-%PLATFORM%.exe
+  - mv Output\Flameshot-Setup.exe Output\Flameshot-Setup-%PLATFORM%-%flameshot_version%.exe
 
 
 artifacts:
   - path: build\distrib\flameshot_%flameshot_version%_win_%PLATFORM%.zip
     name: exe_only
-  - path: build\distrib\Output\Flameshot-Setup-%PLATFORM%.exe
+  - path: build\distrib\Output\Flameshot-Setup-%PLATFORM%-%flameshot_version%.exe
     name: installer

--- a/src/tools/imgs3/imgs3uploader.cpp
+++ b/src/tools/imgs3/imgs3uploader.cpp
@@ -88,10 +88,6 @@ void ImgS3Uploader::handleReply(QNetworkReply *reply) {
         }
     } else {
         QString reason = reply->attribute( QNetworkRequest::HttpReasonPhraseAttribute ).toString();
-        qDebug() << reply->header(QNetworkRequest::ContentDispositionHeader);
-        qDebug() << reply->header(QNetworkRequest::ContentTypeHeader);
-        qDebug() << reply->readAll();
-        qDebug() << reason;
         m_infoLabel->setText(reply->errorString());
     }
     new QShortcut(Qt::Key_Escape, this, SLOT(close()));

--- a/src/tools/imgs3/imgs3uploadertool.cpp
+++ b/src/tools/imgs3/imgs3uploadertool.cpp
@@ -17,7 +17,6 @@
 
 #include "imgs3uploadertool.h"
 #include "imgs3uploader.h"
-#include <QDebug>
 #include <QDir>
 #include <QPainter>
 #include <QSettings>

--- a/src/utils/filenamehandler.cpp
+++ b/src/utils/filenamehandler.cpp
@@ -32,8 +32,12 @@ QString FileNameHandler::parsedPattern() {
 
 QString FileNameHandler::parseFilename(const QString &name) {
     QString res = name;
+    // remove trailing characters '%' in the pattern
     if (name.isEmpty()) {
         res = QLatin1String("%F_%H-%M");
+    }
+    while(res.endsWith('%')) {
+        res.chop(1);
     }
     std::time_t t = std::time(NULL);
 

--- a/win_setup/flameshot.iss
+++ b/win_setup/flameshot.iss
@@ -32,6 +32,7 @@ Source: "flameshot\iconengines\*"; DestDir: "{app}\iconengines"
 Source: "flameshot\imageformats\*"; DestDir: "{app}\imageformats"
 Source: "flameshot\platforms\*"; DestDir: "{app}\platforms"
 Source: "flameshot\translations\*"; DestDir: "{app}\translations"
+Source: "flameshot\vcredist.exe"; DestDir: {app}
 
 [Icons]
 Name: "{commondesktop}\Flameshot"; Filename: "{app}\flameshot.exe"; WorkingDir: "{app}"
@@ -42,6 +43,10 @@ Name: "{group}\FlameShot Documentation"; Filename: "{app}\flameshot-documentatio
 ; don't know what the registry is or if you need to use it, then chances are
 ; you don't need a [Registry] section.
 
+[Run]
+Filename: {app}\vcredist.exe; \
+    Parameters: "/q /passive /Q:a /c:""msiexec /q /i vcredist.msi"""; \
+    StatusMsg: "Installing VC++ 2015 Redistributables..."
 
 [UninstallRun]
 Filename: "taskkill"; Parameters: "/im ""flameshot.exe"" /f"; Flags: runhidden


### PR DESCRIPTION
Fix: Crashes if in filename last character is "%" and application was built with MSVC
Fix: vc_redist-2015 is added into the installation for MS Windows