### PR TITLE
Bugfix/rnd 692 flameshot macos specific issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,4 +63,7 @@ data/flatpak/.flatpak-builder
 .idea/
 .run
 
+# MacOS
+.DS_Store
+
 # End of https://www.gitignore.io/api/snapcraft

--- a/src/core/controller.cpp
+++ b/src/core/controller.cpp
@@ -150,9 +150,12 @@ void Controller::startVisualCapture(const uint id,
 
 #ifdef Q_OS_WIN
         m_captureWindow->show();
+#elif (defined(Q_OS_MAC) || defined(Q_OS_MAC64) || defined(Q_OS_MACOS) ||      \
+       defined(Q_OS_MACX))
+        m_captureWindow->show();
+        m_captureWindow->activateWindow();
 #else
         m_captureWindow->showFullScreen();
-        // m_captureWindow->show(); // Debug
 #endif
     } else {
         emit captureFailed(id);
@@ -250,12 +253,15 @@ void Controller::enableTrayIcon()
       QIcon::fromTheme("flameshot-tray", QIcon(":img/app/flameshot.png"));
     m_trayIcon->setIcon(trayicon);
 
+#if not(defined(Q_OS_WIN) || defined(Q_OS_MAC) || defined(Q_OS_MAC64) ||       \
+        defined(Q_OS_MACOS) || defined(Q_OS_MACX))
     auto trayIconActivated = [this](QSystemTrayIcon::ActivationReason r) {
         if (r == QSystemTrayIcon::Trigger) {
             startVisualCapture();
         }
     };
     connect(m_trayIcon, &QSystemTrayIcon::activated, this, trayIconActivated);
+#endif
 
 #ifdef Q_OS_WIN
     // Ensure proper removal of tray icon when program quits on Windows.

--- a/src/core/controller.cpp
+++ b/src/core/controller.cpp
@@ -152,7 +152,9 @@ void Controller::startVisualCapture(const uint id,
         m_captureWindow->show();
 #elif (defined(Q_OS_MAC) || defined(Q_OS_MAC64) || defined(Q_OS_MACOS) ||      \
        defined(Q_OS_MACX))
-        m_captureWindow->show();
+        // In "Emulate fullscreen mode"
+        //        m_captureWindow->show();
+        m_captureWindow->showFullScreen();
         m_captureWindow->activateWindow();
 #else
         m_captureWindow->showFullScreen();
@@ -185,6 +187,10 @@ void Controller::openConfigWindow()
     if (!m_configWindow) {
         m_configWindow = new ConfigWindow();
         m_configWindow->show();
+#if (defined(Q_OS_MAC) || defined(Q_OS_MAC64) || defined(Q_OS_MACOS) ||        \
+     defined(Q_OS_MACX))
+        m_configWindow->activateWindow();
+#endif
     }
 }
 
@@ -202,6 +208,10 @@ void Controller::openLauncherWindow()
         m_launcherWindow = new CaptureLauncher();
     }
     m_launcherWindow->show();
+#if (defined(Q_OS_MAC) || defined(Q_OS_MAC64) || defined(Q_OS_MACOS) ||        \
+     defined(Q_OS_MACX))
+    m_launcherWindow->activateWindow();
+#endif
 }
 
 void Controller::enableTrayIcon()
@@ -324,6 +334,10 @@ void Controller::showRecentScreenshots()
     }
     m_history->loadHistory();
     m_history->show();
+#if (defined(Q_OS_MAC) || defined(Q_OS_MAC64) || defined(Q_OS_MACOS) ||        \
+     defined(Q_OS_MACX))
+    m_history->activateWindow();
+#endif
 }
 
 void Controller::startFullscreenCapture(const uint id)

--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -37,7 +37,18 @@ ScreenGrabber::ScreenGrabber(QObject* parent)
 QPixmap ScreenGrabber::grabEntireDesktop(bool& ok)
 {
     ok = true;
-#if defined(Q_OS_LINUX) || defined(Q_OS_UNIX)
+#if (defined(Q_OS_MAC) || defined(Q_OS_MAC64) || defined(Q_OS_MACOS) ||        \
+     defined(Q_OS_MACX))
+    QScreen* currentScreen = QGuiApplication::screenAt(QCursor::pos());
+    QPixmap screenPixmap(
+      currentScreen->grabWindow(QApplication::desktop()->winId(),
+                                currentScreen->geometry().x(),
+                                currentScreen->geometry().y(),
+                                currentScreen->geometry().width(),
+                                currentScreen->geometry().height()));
+    screenPixmap.setDevicePixelRatio(currentScreen->devicePixelRatio());
+    return screenPixmap;
+#elif defined(Q_OS_LINUX) || defined(Q_OS_UNIX)
     if (m_info.waylandDectected()) {
         QPixmap res;
         // handle screenshot based on DE
@@ -87,7 +98,7 @@ QPixmap ScreenGrabber::grabEntireDesktop(bool& ok)
         return res;
     }
 #endif
-
+#if defined(Q_OS_LINUX) || defined(Q_OS_UNIX) || defined(Q_OS_WIN)
     QRect geometry;
     for (QScreen* const screen : QGuiApplication::screens()) {
         QRect scrRect = screen->geometry();
@@ -106,6 +117,7 @@ QPixmap ScreenGrabber::grabEntireDesktop(bool& ok)
     QScreen* screen = QApplication::screens()[screenNumber];
     p.setDevicePixelRatio(screen->devicePixelRatio());
     return p;
+#endif
 }
 
 QPixmap ScreenGrabber::grabScreen(int screenNumber, bool& ok)

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -115,10 +115,13 @@ CaptureWidget::CaptureWidget(const uint id,
         resize(pixmap().size());
 #elif (defined(Q_OS_MAC) || defined(Q_OS_MAC64) || defined(Q_OS_MACOS) ||      \
        defined(Q_OS_MACX))
-        setWindowFlags(Qt::WindowStaysOnTopHint | Qt::BypassWindowManagerHint |
-                       Qt::FramelessWindowHint | Qt::NoDropShadowWindowHint |
-                       Qt::ToolTip | Qt::Popup);
-
+        // Emulate fullscreen mode
+        //        setWindowFlags(Qt::WindowStaysOnTopHint |
+        //        Qt::BypassWindowManagerHint |
+        //                       Qt::FramelessWindowHint |
+        //                       Qt::NoDropShadowWindowHint | Qt::ToolTip |
+        //                       Qt::Popup
+        //                       );
         QScreen* currentScreen = QGuiApplication::screenAt(QCursor::pos());
         move(currentScreen->geometry().x(), currentScreen->geometry().y());
         resize(currentScreen->size());

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -85,7 +85,8 @@ CaptureWidget::CaptureWidget(const uint id,
     initContext(savePath, fullScreen);
     initShortcuts();
     m_context.circleCount = 1;
-#ifdef Q_OS_WIN
+#if (defined(Q_OS_WIN) || defined(Q_OS_MAC) || defined(Q_OS_MAC64) ||          \
+     defined(Q_OS_MACOS) || defined(Q_OS_MACX))
     // Top left of the whole set of screens
     QPoint topLeft(0, 0);
 #endif
@@ -99,7 +100,7 @@ CaptureWidget::CaptureWidget(const uint id,
         }
         m_context.origScreenshot = m_context.screenshot;
 
-#ifdef Q_OS_WIN
+#if defined(Q_OS_WIN)
         setWindowFlags(Qt::WindowStaysOnTopHint | Qt::FramelessWindowHint |
                        Qt::Popup);
 
@@ -111,11 +112,21 @@ CaptureWidget::CaptureWidget(const uint id,
             }
         }
         move(topLeft);
+        resize(pixmap().size());
+#elif (defined(Q_OS_MAC) || defined(Q_OS_MAC64) || defined(Q_OS_MACOS) ||      \
+       defined(Q_OS_MACX))
+        setWindowFlags(Qt::WindowStaysOnTopHint | Qt::BypassWindowManagerHint |
+                       Qt::FramelessWindowHint | Qt::NoDropShadowWindowHint |
+                       Qt::ToolTip | Qt::Popup);
+
+        QScreen* currentScreen = QGuiApplication::screenAt(QCursor::pos());
+        move(currentScreen->geometry().x(), currentScreen->geometry().y());
+        resize(currentScreen->size());
 #else
         setWindowFlags(Qt::BypassWindowManagerHint | Qt::WindowStaysOnTopHint |
                        Qt::FramelessWindowHint | Qt::Tool);
-#endif
         resize(pixmap().size());
+#endif
     }
     // Create buttons
     m_buttonHandler = new ButtonHandler(this);
@@ -126,7 +137,7 @@ CaptureWidget::CaptureWidget(const uint id,
             QRect r = screen->geometry();
             r.moveTo(r.x() / screen->devicePixelRatio(),
                      r.y() / screen->devicePixelRatio());
-#ifdef Q_OS_WIN
+#if defined(Q_OS_WIN)
             r.moveTo(r.topLeft() - topLeft);
 #endif
             areas.append(r);

--- a/src/widgets/panel/utilitypanel.cpp
+++ b/src/widgets/panel/utilitypanel.cpp
@@ -42,6 +42,11 @@ UtilityPanel::UtilityPanel(QWidget* parent)
             &QPropertyAnimation::finished,
             m_internalPanel,
             &QWidget::hide);
+
+#if (defined(Q_OS_WIN) || defined(Q_OS_MAC) || defined(Q_OS_MAC64) ||          \
+     defined(Q_OS_MACOS) || defined(Q_OS_MACX))
+    move(0, 0);
+#endif
 }
 
 QWidget* UtilityPanel::toolWidget() const
@@ -81,6 +86,10 @@ void UtilityPanel::show()
     m_showAnimation->setEndValue(QRect(0, 0, width(), height()));
     m_internalPanel->show();
     m_showAnimation->start();
+#if (defined(Q_OS_WIN) || defined(Q_OS_MAC) || defined(Q_OS_MAC64) ||          \
+     defined(Q_OS_MACOS) || defined(Q_OS_MACX))
+    move(0, 0);
+#endif
     QWidget::show();
 }
 


### PR DESCRIPTION
Fixes:
- MacOS - activate new widgets, switch to fullscreen mode+hotkeys 
- MacOS Tool Setting on non-primary screen
- MacOS capture area, full screen mode, system tray area, etc