### PR TITLE
fix - MacOS - no notification in tray on image upload, save to clipboard and other notifications

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -76,7 +76,8 @@ int main(int argc, char* argv[])
         app.setOrganizationName(QStringLiteral("flameshot"));
 
         auto c = Controller::getInstance();
-#if defined(Q_OS_LINUX) || defined(Q_OS_UNIX)
+#if not(defined(Q_OS_MAC) || defined(Q_OS_MAC64) || defined(Q_OS_MACOS) ||     \
+        defined(Q_OS_MACX) || defined(Q_OS_WIN))
         new FlameshotDBusAdapter(c);
         QDBusConnection dbus = QDBusConnection::sessionBus();
         if (!dbus.isConnected()) {
@@ -92,7 +93,8 @@ int main(int argc, char* argv[])
         return app.exec();
     }
 
-#ifndef Q_OS_WIN
+#if not(defined(Q_OS_MAC) || defined(Q_OS_MAC64) || defined(Q_OS_MACOS) ||     \
+        defined(Q_OS_MACX) || defined(Q_OS_WIN))
     /*--------------|
      * CLI parsing  |
      * ------------*/


### PR DESCRIPTION
fix - MacOS - no notification in tray on image upload, save to clipboard and other notifications