### PR TITLE
fix - MacOS - Selected area remains on the screen after saving capture

### DIFF
--- a/src/tools/save/savetool.cpp
+++ b/src/tools/save/savetool.cpp
@@ -68,6 +68,7 @@ void SaveTool::pressed(const CaptureContext& context)
         if (0 ==
             className.compare(CaptureWidget::staticMetaObject.className())) {
             widget->showNormal();
+            widget->hide();
             break;
         }
     }


### PR DESCRIPTION
fix - MacOS - Sometimes selected area remains on the screen after saving capture