### PR TITLE
fix - MacOS - Image is not copied to the clipboard when the 'Use JPG …

### DIFF
--- a/src/config/generalconf.cpp
+++ b/src/config/generalconf.cpp
@@ -389,6 +389,10 @@ void GeneralConf::initUseJpgForClipboard()
       tr("Use JPG format for clipboard (PNG default)"));
     m_layout->addWidget(m_useJpgForClipboard);
 
+#if defined(Q_OS_MACOS)
+    // FIXME - temporary fix to disable option for MacOS
+    m_useJpgForClipboard->hide();
+#endif
     connect(m_useJpgForClipboard,
             &QCheckBox::clicked,
             this,

--- a/src/utils/confighandler.cpp
+++ b/src/utils/confighandler.cpp
@@ -510,9 +510,12 @@ void ConfigHandler::setCopyPathAfterSaveEnabled(const bool value)
 
 bool ConfigHandler::useJpgForClipboard() const
 {
+#if not defined(Q_OS_MACOS)
+    // FIXME - temporary fix to disable option for MacOS
     if (m_settings.contains(QStringLiteral("useJpgForClipboard"))) {
         return m_settings.value(QStringLiteral("useJpgForClipboard")).toBool();
     }
+#endif
     return false;
 }
 

--- a/src/utils/screenshotsaver.cpp
+++ b/src/utils/screenshotsaver.cpp
@@ -29,7 +29,6 @@ ScreenshotSaver::ScreenshotSaver(const unsigned id)
 // dbus, the application freezes.
 void ScreenshotSaver::saveToClipboard(const QPixmap& capture)
 {
-
     // If we are able to properly save the file, save the file and copy to
     // clipboard.
     if ((ConfigHandler().saveAfterCopyValue()) &&
@@ -42,6 +41,7 @@ void ScreenshotSaver::saveToClipboard(const QPixmap& capture)
     // Otherwise only save to clipboard
     else {
         if (ConfigHandler().useJpgForClipboard()) {
+            // FIXME - it doesn't work on MacOS
             QByteArray array;
             QBuffer buffer{ &array };
             QImageWriter imageWriter{ &buffer, "JPEG" };
@@ -58,14 +58,12 @@ void ScreenshotSaver::saveToClipboard(const QPixmap& capture)
                 QMimeData* mimeData = new QMimeData;
                 mimeData->setData("image/jpeg", array);
                 QApplication::clipboard()->setMimeData(mimeData);
-
             } else {
                 SystemNotification().sendMessage(
                   QObject::tr("Error while saving to clipboard"));
                 return;
             }
         } else {
-
             // Need to send message before copying to clipboard
             SystemNotification().sendMessage(
               QObject::tr("Capture saved to clipboard"));


### PR DESCRIPTION
…format for clipboard' checkbox is set