### PR TITLE
fix - Active tool stays active if existing object is selected in the Tool Settings panel

### DIFF
--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -382,6 +382,7 @@ bool CaptureWidget::startDrawObjectTool(const QPoint& pos)
             m_captureToolObjects.append(m_activeTool);
             m_undoStack.push(
               new ModificationCommand(this, m_captureToolObjects));
+            m_activeTool->deleteLater();
             m_activeTool = nullptr;
             m_mouseIsClicked = false;
         }
@@ -1336,6 +1337,7 @@ void CaptureWidget::pushToolToStack()
         }
 
         m_captureToolObjects.append(m_activeTool);
+        m_activeTool->deleteLater();
         m_activeTool = nullptr;
     }
 
@@ -1355,18 +1357,15 @@ void CaptureWidget::drawToolsData(bool updateLayersPanel, bool drawSelection)
             m_context.circleCount++;
         }
         toolItem->process(painter, pixmapItem);
-        if (drawSelection) {
-            if (m_panel->activeLayerIndex() == index) {
-                toolItem->drawObjectSelection(painter);
-            }
-            index++;
-        }
     }
 
     m_context.screenshot = pixmapItem.copy();
     update();
     if (updateLayersPanel) {
         m_panel->fillCaptureTools(m_captureToolObjects.captureToolObjects());
+    }
+
+    if (drawSelection) {
         drawObjectSelection();
     }
 }
@@ -1379,6 +1378,13 @@ void CaptureWidget::drawObjectSelection()
         toolItem->drawObjectSelection(painter);
         m_context.thickness =
           toolItem->thickness() <= 0 ? 0 : toolItem->thickness();
+        if (activeToolObject() && m_activeButton) {
+            // uncheck active tool
+            m_activeButton->setColor(m_uiColor);
+            m_activeButton = nullptr;
+            m_activeTool->deleteLater();
+            m_activeTool = nullptr;
+        }
     }
 }
 


### PR DESCRIPTION
fix - Move tool doesn't work if any object is selected
fix - Active tool stays active if existing object is selected in the Tool Settings panel