### PR TITLE
fix - MacOS - Button "Tool Settings" is not visible on some displays

### DIFF
--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -812,7 +812,7 @@ void CaptureWidget::initPanel()
 #if defined(Q_OS_MACOS)
         panelToggleButton->move(
           0,
-          panelRect.y() + static_cast<int>(panelRect.height() / 2) -
+          static_cast<int>(panelRect.height() / 2) -
             static_cast<int>(panelToggleButton->width() / 2));
 #else
         panelToggleButton->move(panelRect.x(),


### PR DESCRIPTION
fix - MacOS - Button "Tool Settings" is not visible on some displays if displays are vertically aligned