### PR TITLE
fix - undo object on 2nd attempt

### DIFF
--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -420,6 +420,10 @@ bool CaptureWidget::startDrawObjectTool(const QPoint& pos)
 void CaptureWidget::pushObjectsStateToUndoStack()
 {
     m_existingObjectIsChanged = false;
+    // push zero state to be able to do a complete undo
+    if (m_undoStack.count() == 0 || m_undoStack.index() == 0) {
+        m_undoStack.push(new ModificationCommand(this, m_captureToolObjects));
+    }
     m_undoStack.push(new ModificationCommand(this, m_captureToolObjects));
 }
 
@@ -1409,11 +1413,6 @@ void CaptureWidget::updateCursor()
 
 void CaptureWidget::pushToolToStack()
 {
-    // push zero state to be able to do a complete undo
-    if (m_undoStack.count() == 0) {
-        pushObjectsStateToUndoStack();
-    }
-
     // append current tool to the new state
     if (m_activeTool && m_activeButton) {
         disconnect(this,
@@ -1573,6 +1572,11 @@ void CaptureWidget::undo()
     m_lastPressedUndo = true;
     m_lastPressedRedo = false;
     m_undoStack.undo();
+    if (m_undoStack.index() == 0 && m_captureToolObjects.size() > 0) {
+        m_lastPressedUndo = false;
+        m_captureToolObjects.clear();
+        drawToolsData();
+    }
 }
 
 void CaptureWidget::redo()


### PR DESCRIPTION
fix - It is impossible to remove an object using the "Undo the latest modification" button on second attempt (full undo, draw something, full undo again)