### PR TITLE
fix - App freezes and then crashes when changing object line thickness in panel

### DIFF
--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -1204,13 +1204,14 @@ void CaptureWidget::setDrawThickness(const int& t)
 {
     m_context.thickness = qBound(1, t, 100);
     ConfigHandler().setDrawThickness(m_context.thickness);
-    emit thicknessChanged(m_context.thickness);
 
     auto toolItem = activeToolObject();
     if (toolItem) {
         // Change thickness
         emit toolItem->thicknessChanged(t);
         drawToolsData(false, true);
+    } else {
+        emit thicknessChanged(m_context.thickness);
     }
 }
 


### PR DESCRIPTION
fix - App freezes and then crashes when changing object line thickness via Active thickness slider in the tool settings