### PR TITLE
fix - Text modification cannot be undone

### DIFF
--- a/src/tools/capturetool.h
+++ b/src/tools/capturetool.h
@@ -126,6 +126,9 @@ public:
     virtual void setEditMode(bool b) { m_editMode = b; };
     virtual bool editMode() { return m_editMode; };
 
+    // return true if object was change after editMode
+    virtual bool isChanged() { return true; };
+
     // Counter for all object types (currently is used for the CircleCounter
     // only)
     virtual void setCount(int count) { m_count = count; };

--- a/src/tools/text/texttool.cpp
+++ b/src/tools/text/texttool.cpp
@@ -300,3 +300,16 @@ const QPoint* TextTool::pos()
     m_currentPos = m_textArea.topLeft();
     return &m_currentPos;
 }
+
+void TextTool::setEditMode(bool b)
+{
+    if (b) {
+        m_textOld = m_text;
+    }
+    CaptureTool::setEditMode(b);
+}
+
+bool TextTool::isChanged()
+{
+    return QString::compare(m_text, m_textOld, Qt::CaseInsensitive) != 0;
+}

--- a/src/tools/text/texttool.h
+++ b/src/tools/text/texttool.h
@@ -38,6 +38,9 @@ public:
     const QPoint* pos() override;
     void drawObjectSelection(QPainter& painter) override;
 
+    void setEditMode(bool b) override;
+    bool isChanged() override;
+
 protected:
     void copyParams(const TextTool* from, TextTool* to);
     ToolType nameID() const override;
@@ -64,6 +67,7 @@ private:
 
     QFont m_font;
     QString m_text;
+    QString m_textOld;
     int m_size;
     QColor m_color;
     QRect m_textArea;

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -314,6 +314,9 @@ void CaptureWidget::releaseActiveTool()
     if (m_activeTool) {
         if (m_activeTool->editMode()) {
             m_activeTool->setEditMode(false);
+            if (m_activeTool->isChanged()) {
+                pushObjectsStateToUndoStack();
+            }
         }
         if (-1 == m_panel->activeLayerIndex() && m_activeButton) {
             // delete tool if no active selection, otherwise object shouldn't be
@@ -1417,8 +1420,10 @@ void CaptureWidget::updateCursor()
 void CaptureWidget::pushToolToStack()
 {
     // append current tool to the new state
+    bool isChanged = true;
     if (m_activeTool && m_activeTool->editMode()) {
         m_activeTool->setEditMode(false);
+        isChanged = m_activeTool->isChanged();
     }
     if (m_activeTool && m_activeButton) {
         disconnect(this,
@@ -1437,7 +1442,9 @@ void CaptureWidget::pushToolToStack()
         releaseActiveTool();
     }
 
-    pushObjectsStateToUndoStack();
+    if (isChanged) {
+        pushObjectsStateToUndoStack();
+    }
 }
 
 void CaptureWidget::drawToolsData(bool updateLayersPanel, bool drawSelection)


### PR DESCRIPTION
fix - Text modification cannot be undone
fix - Object that was created after the text object disappears after undo editing text