### PR TITLE
fix - Font parameters doesn't disappear in panel on click text item in it

### DIFF
--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -333,6 +333,7 @@ void CaptureWidget::releaseActiveTool()
 void CaptureWidget::uncheckActiveTool()
 {
     // uncheck active tool
+    m_panel->setToolWidget(nullptr);
     m_activeButton->setColor(m_uiColor);
     m_activeButton = nullptr;
     releaseActiveTool();


### PR DESCRIPTION
fix - Font parameters doesn't disappear in panel on click text item in it