### PR TITLE
fix - Phantom is displayed on a screen if the figure was moved after double click

### DIFF
--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -526,8 +526,9 @@ void CaptureWidget::mouseDoubleClickEvent(QMouseEvent* event)
     int activeLayerIndex = m_panel->activeLayerIndex();
     if (activeLayerIndex != -1) {
         // Start object editing
-        m_activeTool = m_captureToolObjects.at(activeLayerIndex);
-        if (m_activeTool && m_activeTool->nameID() == ToolType::TEXT) {
+        auto activeTool = m_captureToolObjects.at(activeLayerIndex);
+        if (activeTool && activeTool->nameID() == ToolType::TEXT) {
+            m_activeTool = activeTool;
             m_mouseIsClicked = false;
             m_context.mousePos = *m_activeTool->pos();
             m_captureToolObjectsBackup = m_captureToolObjects;


### PR DESCRIPTION
Phantom is displayed on a screen if the figure was moved after double click on it and the last changes were undo and redo