### PR TITLE
fix - App crashes if during editing text add any object (one more fix for the same issue)

### DIFF
--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -311,15 +311,14 @@ void CaptureWidget::releaseActiveTool()
 {
     if (m_activeTool) {
         if (m_activeTool->editMode()) {
+            // Object shouldn't be deleted here because it is in the undo/redo
+            // stack, just set current pointer to null
             m_activeTool->setEditMode(false);
             if (m_activeTool->isChanged()) {
                 pushObjectsStateToUndoStack();
             }
-        }
-        if (-1 == m_panel->activeLayerIndex() && m_activeButton) {
-            // delete tool if no active selection, otherwise object shouldn't be
-            // deleted, because it is in undo/redo stack
-            m_activeTool->deleteLater();
+        } else {
+            delete m_activeTool;
         }
         m_activeTool = nullptr;
     }
@@ -1072,11 +1071,7 @@ void CaptureWidget::loadDrawThickness()
 
 void CaptureWidget::processTool(CaptureTool* t)
 {
-    auto backup = m_activeTool;
-    // The tool is active during the pressed().
-    m_activeTool = t;
     t->pressed(m_context);
-    m_activeTool = backup;
 }
 
 void CaptureWidget::handleButtonSignal(CaptureTool::Request r)


### PR DESCRIPTION
fix - App crashes if during editing text add any object (one more fix for the same issue)