### PR TITLE
Possibility to overwrite GIT_API_URL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,9 +4,14 @@ cmake_minimum_required(VERSION 3.13)
 set(FLAMESHOT_VERSION 0.10.0.1)
 
 # Flameshot-org
-set(GIT_API_URL "https://api.github.com/repos/flameshot-org/flameshot/releases/latest")
-# Namecheap
-# set(GIT_API_URL "https://api.github.com/repos/namecheap/flameshot/releases/latest")
+if(DEFINED ENV{FLAMESHOT_GIT_API_URL})
+  # Can be set in github secrets
+  set(GIT_API_URL "$ENV{FLAMESHOT_GIT_API_URL}")
+  # Namecheap default:
+  # set(GIT_API_URL "https://api.github.com/repos/namecheap/flameshot/releases/latest")
+else()
+  set(GIT_API_URL "https://api.github.com/repos/flameshot-org/flameshot/releases/latest")
+endif()
 
 # TODO - fix it for all linux distros
 #find_package (Git)


### PR DESCRIPTION
Possibility to overwrite GIT_API_URL for the updates checker (community/Namecheap) via GITHUB envs and do not handle it in the code after the merge