### PR TITLE
The "copy to clipboard" button keeps the margin of the selected annotation

### DIFF
--- a/src/tools/copy/copytool.cpp
+++ b/src/tools/copy/copytool.cpp
@@ -41,6 +41,7 @@ CaptureTool* CopyTool::copy(QObject* parent)
 
 void CopyTool::pressed(const CaptureContext& context)
 {
+    emit requestAction(REQ_CLEAR_SELECTION);
     emit requestAction(REQ_CAPTURE_DONE_OK);
     ScreenshotSaver().saveToClipboard(context.selectedScreenshotArea());
 }


### PR DESCRIPTION
The "copy to clipboard" button keeps the margin of the selected annotation #1879